### PR TITLE
start pulseaudio the x11-oriented way

### DIFF
--- a/bin/install_pulse
+++ b/bin/install_pulse
@@ -21,7 +21,7 @@ msg "writing configuration"
 sed -i 's/bindsym \$mod+Ctrl+m exec terminal -e '\''alsamixer'\''/#bindsym \$mod+Ctrl+m exec terminal -e '\''alsamixer'\''/g' $i3configfile
 
 #uncomment needed config
-sed -i 's/#exec --no-startup-id pulseaudio/exec --no-startup-id pulseaudio/g' $i3configfile
+sed -i 's/#exec --no-startup-id start-pulseaudio-x11/exec --no-startup-id start-pulseaudio-x11/g' $i3configfile
 #sed -i 's/#exec --no-startup-id pa-applet/exec --no-startup-id pa-applet/g' $i3configfile
 sed -i 's/#bindsym \$mod+Ctrl+m exec pavucontrol/bindsym \$mod+Ctrl+m exec pavucontrol/g' $i3configfile
 


### PR DESCRIPTION
I could be wrong but I think this is the way you're supposed to start pulseaudio.
Or maybe you're supposed to use systemctl --user enable
Either way, start-pulseaudio-x11 is the only way that worked for me