### PR TITLE
Account for custom GTK2 RC location in setcursor

### DIFF
--- a/bin/setcursor
+++ b/bin/setcursor
@@ -3,7 +3,7 @@
 # /usr/bin/setcursor
 
 # config files
-gtk2=$HOME/.gtkrc-2.0
+gtk2=${GTK2_RC_FILES:-$HOME/.gtkrc-2.0}
 gtk3=$HOME/.config/gtk-3.0/settings.ini
 [[ -e $HOME/.extend.Xresources ]] && xr=$HOME/.extend.Xresources || xr=$HOME/.Xresources
 


### PR DESCRIPTION
GTK 2 allows the user to configure the location of gtkrc through the environment variable `GTK2_RC_FILES` ([reference](https://wiki.archlinux.org/title/GTK)).

If the user does this, the `setcursor` fails because it expects to find the file in its default location:
```
grep: /home/sodic/.gtkrc-2.0: No such file or directory
setting cursortheme "xcursor-breeze"
sed: can't read /home/sodic/.gtkrc-2.0: No such file or directory
```
This PR fixes the issue - we first try to use `GTK2_RC_FILES` and fall back to the default location only when the variable is empty.